### PR TITLE
一个格式化修改

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -3,7 +3,7 @@
  * Released under the MIT license.
  * https://github.com/cssmagic/action
  */
-var action = function () {
+var action = (function () {
 	'use strict'
 
 	//namespace
@@ -21,6 +21,7 @@ var action = function () {
 		}
 		return _formatActionName(result)
 	}
+  
 	function _formatActionName(s) {
 		return s ? $.trim(String(s).replace(/^[#!\s]+/, '')) : ''
 	}
@@ -36,6 +37,7 @@ var action = function () {
 			_handle(actionName, this)
 		})
 	}
+  
 	function _handle(actionName, context) {
 		if (!actionName) {
 			/** DEBUG_INFO_START **/
@@ -60,35 +62,45 @@ var action = function () {
 
 	//api
 	action.add = function (actionSet) {
-		if ($.isPlainObject(actionSet)) {
-			$.each(actionSet, function (key, value) {
-				var actionName = _formatActionName(key)
-				if (actionName) {
-					if ($.isFunction(value)) {
-						/** DEBUG_INFO_START **/
-						if (_actionList[actionName]) {
-							console.warn('[Action] The existed action `%s` has been overridden.', actionName)
-						}
-						/** DEBUG_INFO_END **/
+    if (!$.isPlainObject(actionSet)){
+      /** DEBUG_INFO_START **/
+      console.warn('[Action] Param must be a plain object.')
+      /** DEBUG_INFO_END **/
+      
+      return
+    }
+    
+    $.each(actionSet, function (key, value) {
+      var actionName = _formatActionName(key)
+      
+      if(!actionName) {
+        /** DEBUG_INFO_START **/
+        console.error('[Action] The action name `%s` is invalid.', key)
+        /** DEBUG_INFO_END **/
+        
+        return
+      }
+      
+      if(!$.isFunction(value)) {
+        /** DEBUG_INFO_START **/
+        console.error('[Action] The function for action `%s` is invalid.', actionName)
+        /** DEBUG_INFO_END **/
+        
+        return
+      }
+      
+      /** DEBUG_INFO_START **/
+      if (_actionList[actionName]) {
+        console.warn('[Action] The existed action `%s` has been overridden.', actionName)
+      }
+      /** DEBUG_INFO_END **/
 
-						_actionList[actionName] = value
-					} else {
-						/** DEBUG_INFO_START **/
-						console.error('[Action] The function for action `%s` is invalid.', actionName)
-						/** DEBUG_INFO_END **/
-					}
-				} else {
-					/** DEBUG_INFO_START **/
-					console.error('[Action] The action name `%s` is invalid.', key)
-					/** DEBUG_INFO_END **/
-				}
-			})
-		} else {
-			/** DEBUG_INFO_START **/
-			console.warn('[Action] Param must be a plain object.')
-			/** DEBUG_INFO_END **/
-		}
+      _actionList[actionName] = value
+      
+    })
+    
 	}
+  
 	action.trigger = function (actionName, context) {
 		return _handle(_formatActionName(actionName), context)
 	}
@@ -106,4 +118,4 @@ var action = function () {
 	//exports
 	return action
 
-}()
+})()


### PR DESCRIPTION
1）改成前面加括号，仅仅是为了让用户 一眼就看出 action 定义的是 自运行的匿名函数，而不需要拖到末尾来判断。
2）一些 if 语句的格式化，让代码阅读起来更便捷一点。
3）经过了测试。