### PR TITLE
fix data(action) to attr(data-action)

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -14,7 +14,7 @@ var action = (function () {
 
 	// util
 	function _getActionName($elem) {
-		var result = $elem.data('action') || ''
+		var result = $elem.attr('data-action') || ''
 		if (!result) {
 			var href = $.trim($elem.attr('href'))
 			if (href && href.indexOf('#') === 0) result = href


### PR DESCRIPTION
将data("action")变成attr("data-action")，防止由于data调用和attr调用混合导致的jquery缓存池存取值不一。